### PR TITLE
Semicolon and Bootstrap Class Typo.

### DIFF
--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -5,7 +5,7 @@ class App extends Component {
     constructor(props) {
         super(props);
 
-        this.state = {}
+        this.state = {};
     }
 
 
@@ -48,7 +48,7 @@ class App extends Component {
                 <br/>
                 <br/>
                 <div>
-                    <div className="container col-md-12s">
+                    <div className="container col-md-12">
                         {this.props.main}
                     </div>
                 </ div >


### PR DESCRIPTION
Added semicolon on the constructor setState.
Deleted the 's' after col-md-12.